### PR TITLE
add maemo and meego to the user agent list

### DIFF
--- a/lib/rack/mobile-detect.rb
+++ b/lib/rack/mobile-detect.rb
@@ -122,7 +122,7 @@ module Rack
                    'x320|x240|j2me|sgh|portable|sprint|docomo|kddi|softbank|android|mmp|' +
                    'pdxgw|netfront|xiino|vodafone|portalmmm|sagem|mot-|sie-|ipod|up\\.b|' +
                    'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
-                   'mobile', true)
+                   'mobile|maemo|meego', true)
 
       # A URL that specifies a single redirect-url for any device
       @redirect_to = options[:redirect_to]


### PR DESCRIPTION
It seems for the Nokia N9 the string 'nokia' isn't enough to detect it (?)
see also: diaspora/diaspora#3425
and for an example user agent string: https://bugzilla.mozilla.org/show_bug.cgi?id=682969
